### PR TITLE
Do not empty available vehicles list on every new scan

### DIFF
--- a/LocoSwap.Language/Resources/Resources.Designer.cs
+++ b/LocoSwap.Language/Resources/Resources.Designer.cs
@@ -115,6 +115,15 @@ namespace LocoSwap.Language {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Clear.
+        /// </summary>
+        public static string clear_vehicles {
+            get {
+                return ResourceManager.GetString("clear_vehicles", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Close.
         /// </summary>
         public static string close {

--- a/LocoSwap.Language/Resources/Resources.de.resx
+++ b/LocoSwap.Language/Resources/Resources.de.resx
@@ -135,6 +135,9 @@
   <data name="change_number" xml:space="preserve">
     <value>Nummer ändern</value>
   </data>
+  <data name="clear_vehicles" xml:space="preserve">
+    <value>Löschen</value>
+  </data>
   <data name="close" xml:space="preserve">
     <value>Schließen</value>
   </data>

--- a/LocoSwap.Language/Resources/Resources.resx
+++ b/LocoSwap.Language/Resources/Resources.resx
@@ -135,6 +135,9 @@
   <data name="change_number" xml:space="preserve">
     <value>Change number</value>
   </data>
+  <data name="clear_vehicles" xml:space="preserve">
+    <value>Clear</value>
+  </data>
   <data name="close" xml:space="preserve">
     <value>Close</value>
   </data>

--- a/LocoSwap.Language/Resources/Resources.ru.resx
+++ b/LocoSwap.Language/Resources/Resources.ru.resx
@@ -132,6 +132,9 @@
   <data name="change_number" xml:space="preserve">
     <value>Изменить номер</value>
   </data>
+  <data name="clear_vehicles" xml:space="preserve">
+    <value>очищать</value>
+  </data>
   <data name="close" xml:space="preserve">
     <value>Закрыть</value>
   </data>

--- a/LocoSwap/ScenarioEditWindow.xaml
+++ b/LocoSwap/ScenarioEditWindow.xaml
@@ -97,7 +97,8 @@
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>
-        <Button x:Name="ScanButton" IsEnabled="{Binding VehicleScanInProgress, Converter={StaticResource InverseBooleanConverter}}" Content="{x:Static lang:Resources.look_up_vehicles}" Margin="898,433,0,0" VerticalAlignment="Top" Click="ScanButton_Click" Height="26" HorizontalAlignment="Left" Width="155"/>
+        <Button x:Name="ScanButton" IsEnabled="{Binding VehicleScanInProgress, Converter={StaticResource InverseBooleanConverter}}" Content="{x:Static lang:Resources.look_up_vehicles}" Margin="898,433,0,0" VerticalAlignment="Top" Click="ScanButton_Click" Height="26" HorizontalAlignment="Left" Width="114"/>
+        <Button x:Name="ClearButton" Content="{x:Static lang:Resources.clear_vehicles}" Margin="1026,433,0,0" VerticalAlignment="Top" Click="AvailableVehiclesClearButton_Click" Height="26" HorizontalAlignment="Left" Width="73"/>
         <Button Visibility="{Binding VehicleScanInProgress, Converter={StaticResource BoolToVis}}" x:Name="CancelScanningButton" Content="{x:Static lang:Resources.cancel}" Margin="0,433,20,0" VerticalAlignment="Top" Height="26" Click="CancelScanningButton_Click" HorizontalAlignment="Right" Width="75"/>
         <Button x:Name="AddToRulesButton" Content="{x:Static lang:Resources.add_to_rules}" HorizontalAlignment="Left" Margin="746,493,0,0" VerticalAlignment="Top" Width="147" Height="26" Click="AddToRulesButton_Click"/>
         <Button x:Name="ReplaceIdenticalButton" Content="{x:Static lang:Resources.replace_identical}" HorizontalAlignment="Left" Margin="593,493,0,0" VerticalAlignment="Top" Width="148" Height="26" Click="ReplaceIdenticalButton_Click"/>

--- a/LocoSwap/ScenarioEditWindow.xaml.cs
+++ b/LocoSwap/ScenarioEditWindow.xaml.cs
@@ -174,7 +174,7 @@ namespace LocoSwap
             ViewModel.VehicleScanInProgress = true;
             List<string> files = Directory.GetFiles(path, "*.bin", SearchOption.AllDirectories).ToList();
             List<string> apFiles = Directory.GetFiles(path, "*.ap", SearchOption.AllDirectories).ToList();
-            ViewModel.AvailableVehicles.Clear();
+
             ViewModel.LoadingInformation = LocoSwap.Language.Resources.scanning_bin_files;
             var startDateTime = DateTime.Now;
             var binTask = Task.Run(() =>
@@ -459,6 +459,11 @@ namespace LocoSwap
                 vehicle.Number = number;
                 ViewModel.Scenario.ChangeVehicleNumber(consist.Idx, vehicle.Idx, number);
             }
+        }
+
+        private void AvailableVehiclesClearButton_Click(object sender, RoutedEventArgs e)
+        {
+            ViewModel.AvailableVehicles.Clear();
         }
 
         private void ReplaceIdenticalButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
The "available vehicles" list does not clear anymore when starting a new scan.
Instead, a "Clear" button is provided.