### PR TITLE
Append a [LoSw] suffix to edited scenario name

### DIFF
--- a/LocoSwap/Scenario.cs
+++ b/LocoSwap/Scenario.cs
@@ -634,6 +634,17 @@ namespace LocoSwap
             xmlWriterSettings.Encoding = new UTF8Encoding(false);
 
             FileStream stream = new FileStream(propertiesXmlPath, FileMode.Create);
+
+            // Append a suffix to scenario DisplayName
+            IEnumerable<XElement> displayNameLanguageNodes = ScenarioProperties.XPathSelectElements("/cScenarioProperties/DisplayName/Localisation-cUserLocalisedString/*");
+            foreach (XElement displayNameLanguageNode in displayNameLanguageNodes)
+            {
+                if (displayNameLanguageNode.Name != "Key" && displayNameLanguageNode.Value != "" && !displayNameLanguageNode.Value.EndsWith("[LoSw]"))
+                {
+                    displayNameLanguageNode.SetValue(displayNameLanguageNode.Value + " [LoSw]");
+                }
+            }
+
             using (XmlWriter writer = XmlWriter.Create(stream, xmlWriterSettings))
             {
                 ScenarioProperties.Save(writer);


### PR DESCRIPTION
Add a "[LoSw]" suffix to edited scenario names.
This is useful as a reminder that the scenario has been altered, and that a backup is available in the scenario directory.