### PR TITLE
Do not alter line breaks

### DIFF
--- a/LocoSwap/Scenario.cs
+++ b/LocoSwap/Scenario.cs
@@ -632,6 +632,7 @@ namespace LocoSwap
             xmlWriterSettings.Indent = true;
             xmlWriterSettings.IndentChars = "\t";
             xmlWriterSettings.Encoding = new UTF8Encoding(false);
+            xmlWriterSettings.NewLineHandling = NewLineHandling.None;
 
             FileStream stream = new FileStream(propertiesXmlPath, FileMode.Create);
             using (XmlWriter writer = XmlWriter.Create(stream, xmlWriterSettings))

--- a/LocoSwap/TsSerializer.cs
+++ b/LocoSwap/TsSerializer.cs
@@ -66,6 +66,7 @@ namespace LocoSwap
             xmlWriterSettings.Indent = true;
             xmlWriterSettings.IndentChars = "\t";
             xmlWriterSettings.Encoding = new UTF8Encoding(false);
+            xmlWriterSettings.NewLineHandling = NewLineHandling.None;
 
             FileStream stream = new FileStream(xmlPath, FileMode.Create);
             using (XmlWriter writer = XmlWriter.Create(stream, xmlWriterSettings))


### PR DESCRIPTION
Some portals (for instance "Tonbridge Dn Fast" on Chatham mainline) have "\n" line breaks in their name.
When saving, LocoSwap replaced all these line breaks by Windows-style "\r\n" which would break these portals references inside scenarios.